### PR TITLE
add devcontainer support

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,19 @@
+FROM archlinux:latest
+
+ENV PIP_NO_CACHE_DIR=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+RUN pacman -Syu --noconfirm && \
+    pacman -S --noconfirm base-devel python python-pip python-virtualenv jupyter-notebook \
+                           git gcc pkgconf cmake ffmpeg 
+
+RUN pacman -Syu --noconfirm && \
+    pacman -S --noconfirm sudo && \
+    useradd --create-home --shell /bin/bash --groups wheel vscode && \
+    echo '%wheel ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers
+
+USER vscode
+
+
+CMD [ "/bin/bash" ]

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,18 @@
+{
+	"name": "SOCSIM devcontainer",
+	"build": {
+		"dockerfile": "Dockerfile"
+	},
+	"customizations": {
+		"vscode": {
+			"settings": {},
+			"extensions": ["ms-toolsai.jupyter","ms-python.vscode-python-envs","ms-python.python"]
+		}
+	},
+	"workspaceFolder": "/workspaces/SocSIM",
+	"mounts": [
+		"source=${localWorkspaceFolder},target=/workspaces/socsim,type=bind"
+	],
+	"postCreateCommand": "python -m venv .venvsocsim && . .venvsocsim/bin/activate && pip install -r requirements.txt && pip install ipympl&& pip install -e . ",
+	"remoteUser": "vscode"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -342,3 +342,6 @@ docsrc/build
 .vscode
 *.sln
 *.egg-info
+
+# venv
+.venvsocsim


### PR DESCRIPTION
Devcontainers allow users to use containers as dev environment with all dependencies pre-installed. see https://code.visualstudio.com/docs/devcontainers/containers for more information. This pull request adds a devcontainer environment for socsim.


log from devcontainer installing the project:
```
...
Obtaining file:///workspaces/SocSIM
  Installing build dependencies ... done
  Checking if build backend supports build_editable ... done
  Getting requirements to build editable ... done
  Preparing editable metadata (pyproject.toml) ... done
Requirement already satisfied: numpy in ./.venvsocsim/lib/python3.13/site-packages (from SocSIM==0.2.0) (2.2.6)
Requirement already satisfied: matplotlib in ./.venvsocsim/lib/python3.13/site-packages (from SocSIM==0.2.0) (3.10.3)
Requirement already satisfied: tqdm in ./.venvsocsim/lib/python3.13/site-packages (from SocSIM==0.2.0) (4.67.1)
Requirement already satisfied: numba in ./.venvsocsim/lib/python3.13/site-packages (from SocSIM==0.2.0) (0.61.2)
Requirement already satisfied: zarr in ./.venvsocsim/lib/python3.13/site-packages (from SocSIM==0.2.0) (3.1.0)
Requirement already satisfied: contourpy>=1.0.1 in ./.venvsocsim/lib/python3.13/site-packages (from matplotlib->SocSIM==0.2.0) (1.3.3)
Requirement already satisfied: cycler>=0.10 in ./.venvsocsim/lib/python3.13/site-packages (from matplotlib->SocSIM==0.2.0) (0.12.1)
Requirement already satisfied: fonttools>=4.22.0 in ./.venvsocsim/lib/python3.13/site-packages (from matplotlib->SocSIM==0.2.0) (4.59.0)
Requirement already satisfied: kiwisolver>=1.3.1 in ./.venvsocsim/lib/python3.13/site-packages (from matplotlib->SocSIM==0.2.0) (1.4.8)
Requirement already satisfied: packaging>=20.0 in ./.venvsocsim/lib/python3.13/site-packages (from matplotlib->SocSIM==0.2.0) (25.0)
Requirement already satisfied: pillow>=8 in ./.venvsocsim/lib/python3.13/site-packages (from matplotlib->SocSIM==0.2.0) (11.3.0)
Requirement already satisfied: pyparsing>=2.3.1 in ./.venvsocsim/lib/python3.13/site-packages (from matplotlib->SocSIM==0.2.0) (3.2.3)
Requirement already satisfied: python-dateutil>=2.7 in ./.venvsocsim/lib/python3.13/site-packages (from matplotlib->SocSIM==0.2.0) (2.9.0.post0)
Requirement already satisfied: six>=1.5 in ./.venvsocsim/lib/python3.13/site-packages (from python-dateutil>=2.7->matplotlib->SocSIM==0.2.0) (1.17.0)
Requirement already satisfied: llvmlite<0.45,>=0.44.0dev0 in ./.venvsocsim/lib/python3.13/site-packages (from numba->SocSIM==0.2.0) (0.44.0)
Requirement already satisfied: donfig>=0.8 in ./.venvsocsim/lib/python3.13/site-packages (from zarr->SocSIM==0.2.0) (0.8.1.post1)
Requirement already satisfied: numcodecs>=0.14 in ./.venvsocsim/lib/python3.13/site-packages (from numcodecs[crc32c]>=0.14->zarr->SocSIM==0.2.0) (0.16.1)
Requirement already satisfied: typing-extensions>=4.9 in ./.venvsocsim/lib/python3.13/site-packages (from zarr->SocSIM==0.2.0) (4.14.1)
Requirement already satisfied: pyyaml in ./.venvsocsim/lib/python3.13/site-packages (from donfig>=0.8->zarr->SocSIM==0.2.0) (6.0.2)
Requirement already satisfied: crc32c>=2.7 in ./.venvsocsim/lib/python3.13/site-packages (from numcodecs[crc32c]>=0.14->zarr->SocSIM==0.2.0) (2.7.1)
Building wheels for collected packages: SocSIM
  Building editable for SocSIM (pyproject.toml) ... done
  Created wheel for SocSIM: filename=socsim-0.2.0-0.editable-py3-none-any.whl size=7583 sha256=356a1fd8a2c28a04d6c66b9a19ef7fde38414f94094b951ab0a0eedc8de3cedc
  Stored in directory: /tmp/pip-ephem-wheel-cache-dbnrpayn/wheels/0b/e6/46/c0e561cd91954e2a5736b963050d0fa93d3229ac9c32f3c80f
Successfully built SocSIM
Installing collected packages: SocSIM
Successfully installed SocSIM-0.2.0
```